### PR TITLE
fix: Update test script to run vitest and enable 12-hour format in date display

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:check": "prettier --check .",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "prepare": "husky",

--- a/src/components/features/issues/IssueCard.tsx
+++ b/src/components/features/issues/IssueCard.tsx
@@ -94,6 +94,7 @@ function IssueCardComponent({
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
+      hour12: true,
     }).format(new Date(dateString));
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Dates on issue cards now use a 12-hour clock format (e.g., 3:45 PM) for improved readability.

* **Tests**
  * Updated the test command to use an explicit runner, improving test consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->